### PR TITLE
Remove getTrackFeature method

### DIFF
--- a/demos/simple/demo.js
+++ b/demos/simple/demo.js
@@ -94,7 +94,6 @@ function main() {
   document.querySelector('#undo').addEventListener('click', () => trackManager.undo());
   document.querySelector('#redo').addEventListener('click', () => trackManager.redo());
   document.querySelector('#getTrackData').addEventListener('click', () => {
-    trackManager.getTrackFeature();
     const features = [
       ...trackManager.getControlPoints(),
       ...trackManager.getSegments(),

--- a/src/interaction/TrackData.ts
+++ b/src/interaction/TrackData.ts
@@ -3,7 +3,6 @@ import Feature from 'ol/Feature.js';
 import LineString from 'ol/geom/LineString.js';
 import MultiPoint from 'ol/geom/MultiPoint.js';
 import Point from 'ol/geom/Point.js';
-import type {Coordinate} from 'ol/coordinate.js';
 
 interface ParsedFeatures {
   segments: Array<Feature<LineString>>;
@@ -111,21 +110,6 @@ export default class TrackData {
 
   getSegments(): Array<Feature<LineString>> {
     return this.segments;
-  }
-
-  getLineString(): LineString {
-    const lineCoords: Coordinate[] = [];
-    for (const feature of this.segments) {
-      const segmentCoords = feature.getGeometry().getCoordinates();
-      // remove the overlap between the last coordinate of a segment and
-      // the first coordinate of the next one
-      const overlapping = lineCoords.length > 0 && equals(segmentCoords[0], lineCoords[lineCoords.length - 1]);
-      for (let i = overlapping ? 1 : 0; i < segmentCoords.length; ++i) {
-        lineCoords.push(segmentCoords[i].slice(0, 3));
-      }
-    }
-    console.assert(isXYZ(lineCoords));
-    return new LineString(lineCoords);
   }
 
   insertControlPointAt(point: Feature<Point>, index: number): Feature<LineString> | undefined {
@@ -352,14 +336,4 @@ function createStraightSegment(featureFrom: Feature<Point>, featureTo: Feature<P
   segment.set('type', 'segment');
 
   return segment;
-}
-
-function isXYZ(coordinates: Coordinate[]): boolean {
-  for (let i = 0, ii = coordinates.length; i < ii; i++) {
-    const coord = coordinates[i];
-    if (coord.length !== 3 || !coord.every(num => typeof num === 'number')) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/src/interaction/TrackManager.js
+++ b/src/interaction/TrackManager.js
@@ -531,14 +531,6 @@ class TrackManager {
   }
 
   /**
-   * Return the whole track as one line string in a feature.
-   * @return {Feature<LineString>}
-   */
-  getTrackFeature() {
-    return new Feature(this.trackData_.getLineString());
-  }
-
-  /**
    * Add new event listener to be notified on track changes.
    * @param {Function} fn EventListener
    */


### PR DESCRIPTION
The track is effectively a multiline string in edittrack.
Returning a single linestring does not make sense.

Applications should directly use the `getSegments` method and implement their particular logics.