### PR TITLE
Expose the render method to allow external app to force a render

### DIFF
--- a/src/interaction/TrackManager.js
+++ b/src/interaction/TrackManager.js
@@ -368,6 +368,7 @@ class TrackManager {
     }
     this.interaction_.setActive(edit);
     this.mode_ = mode || '';
+    this.render();
   }
 
   /**
@@ -619,6 +620,11 @@ class TrackManager {
         this.notifyTrackChangeEventListeners_(false);
       }
     }
+  }
+
+  render() {
+    this.source_.changed();
+    this.shadowTrackLayer_.getSource().changed();
   }
 }
 


### PR DESCRIPTION
Styling is managed by the external app.
OpenLayers only re-render when it detects that something changed. For times where automatic detection is not possible we expose this render method.