### PR TITLE
Compute history entry count

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {default as TrackManager} from './interaction/TrackManager';
+export {default as HistoryManager} from './interaction/HistoryManager';
 
 export {default as ExtractFromSegmentProfiler} from './profiler/ExtractFromSegment';
 export {default as FallbackProfiler} from './profiler/Fallback';

--- a/src/interaction/HistoryManager.ts
+++ b/src/interaction/HistoryManager.ts
@@ -42,6 +42,6 @@
   }
 
   linear(): number {
-    return this.historyIndex;
+    return this.historyLinear;
   }
 }

--- a/src/interaction/HistoryManager.ts
+++ b/src/interaction/HistoryManager.ts
@@ -1,10 +1,12 @@
 
  export default class HistoryManager<StateType> {
   private history: StateType[] = [];
+  private historyLinear = -1;
   private historyIndex = -1;
 
   add(state: StateType) {
     this.historyIndex++;
+    this.historyLinear++;
     this.history[this.historyIndex] = state;
     this.history.splice(this.historyIndex + 1);
   }
@@ -36,6 +38,10 @@
   }
 
   position(): number {
+    return this.historyIndex;
+  }
+
+  linear(): number {
     return this.historyIndex;
   }
 }

--- a/src/interaction/HistoryManager.ts
+++ b/src/interaction/HistoryManager.ts
@@ -2,7 +2,7 @@
  export default class HistoryManager<StateType> {
   private history: StateType[] = [];
   private historyIndex = -1;
-  private historyEntryCount = -1;
+  private historyEntryCount = 0;
 
   add(state: StateType) {
     this.historyIndex++;

--- a/src/interaction/HistoryManager.ts
+++ b/src/interaction/HistoryManager.ts
@@ -1,12 +1,12 @@
 
  export default class HistoryManager<StateType> {
   private history: StateType[] = [];
-  private historyLinear = -1;
   private historyIndex = -1;
+  private historyEntryCount = -1;
 
   add(state: StateType) {
     this.historyIndex++;
-    this.historyLinear++;
+    this.historyEntryCount++;
     this.history[this.historyIndex] = state;
     this.history.splice(this.historyIndex + 1);
   }
@@ -41,7 +41,7 @@
     return this.historyIndex;
   }
 
-  linear(): number {
-    return this.historyLinear;
+  entryCount(): number {
+    return this.historyEntryCount;
   }
 }

--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -527,8 +527,8 @@ export default class TrackManager<POIMeta> {
     return this.historyManager_.position();
   }
 
-  get historyLinear(): number {
-    return this.historyManager_.linear();
+  get historyEntryCount(): number {
+    return this.historyManager_.entryCount();
   }
 
   /**

--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -527,6 +527,10 @@ export default class TrackManager<POIMeta> {
     return this.historyManager_.position();
   }
 
+  get historyLinear(): number {
+    return this.historyManager_.linear();
+  }
+
   /**
    * Undo one drawing step
    */


### PR DESCRIPTION
I need to keep track of how many entries we have in the history to synchronize with stopovers history on the app side. 

In most cases we could use the history length, but when an undo is done and a new change is added to the history, the history from that point on is removed. The length remains the same, which can trick into thinking both histories are in sync.