### PR TITLE
Allow users to control cursor style in view mode

### DIFF
--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -165,10 +165,6 @@ export default class TrackManager<POIMeta> {
         layerFilter: l => l === options.trackLayer,
         hitTolerance: this.hitTolerance_,
       });
-      const cursor = (this.interaction_.getActive() && hover) ? 'pointer' : '';
-      if (!this.cursorStyleControl_ && this.map_.getTargetElement().style.cursor !== cursor) {
-        this.map_.getTargetElement().style.cursor = cursor;
-      }
       if (!this.interaction_.getActive() && this.trackHoverEventListeners_.length > 0) {
         debouncedMapToProfileUpdater(event.coordinate, hover);
       }

--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -53,7 +53,7 @@ export interface Options {
   /**
    * Allows client applications to control cursor style in view mode. 
    */
-  viewModePointerControl: boolean;
+  cursorStyleControl: boolean;
 }
 
 
@@ -70,7 +70,7 @@ export default class TrackManager<POIMeta> {
   }
   private shadowTrackLayer_: VectorLayer<VectorSource>;
   private hitTolerance_: number;
-  private viewModePointerControl_ = false;
+  private cursorStyleControl_ = false;
   public snapping = true;
   private mode_: TrackMode = '';
   private submode_: TrackSubMode = '';
@@ -97,7 +97,7 @@ export default class TrackManager<POIMeta> {
     this.trackLayer_ = options.trackLayer;
     this.shadowTrackLayer_ = options.shadowTrackLayer;
     this.hitTolerance_ = options.hitTolerance !== undefined ? options.hitTolerance : 20;
-    this.viewModePointerControl_ = options.viewModePointerControl || false;
+    this.cursorStyleControl_ = options.cursorStyleControl || false;
     console.assert(!!options.router);
 
     this.router_ = options.router;
@@ -165,13 +165,8 @@ export default class TrackManager<POIMeta> {
         layerFilter: l => l === options.trackLayer,
         hitTolerance: this.hitTolerance_,
       });
-      let cursor: string;
-      if (this.interaction_.getActive() && hover) {
-         cursor = 'pointer'
-      } else if (!this.viewModePointerControl_ || !hover) {
-          cursor = ''
-      }
-      if (cursor && this.map_.getTargetElement().style.cursor !== cursor) {
+      const cursor = (this.interaction_.getActive() && hover) ? 'pointer' : '';
+      if (!this.cursorStyleControl_ && this.map_.getTargetElement().style.cursor !== cursor) {
         this.map_.getTargetElement().style.cursor = cursor;
       }
       if (!this.interaction_.getActive() && this.trackHoverEventListeners_.length > 0) {

--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -50,6 +50,10 @@ export interface Options {
    * Pixel tolerance for considering the pointer close enough to a segment for snapping.
    */
   hitTolerance: number;
+  /**
+   * Allows users to control cursor style in view mode. 
+   */
+  viewModePointerControl: boolean;
 }
 
 
@@ -66,6 +70,7 @@ export default class TrackManager<POIMeta> {
   }
   private shadowTrackLayer_: VectorLayer<VectorSource>;
   private hitTolerance_: number;
+  private viewModePointerControl_ = false;
   public snapping = true;
   private mode_: TrackMode = '';
   private submode_: TrackSubMode = '';
@@ -92,6 +97,7 @@ export default class TrackManager<POIMeta> {
     this.trackLayer_ = options.trackLayer;
     this.shadowTrackLayer_ = options.shadowTrackLayer;
     this.hitTolerance_ = options.hitTolerance !== undefined ? options.hitTolerance : 20;
+    this.viewModePointerControl_ = options.viewModePointerControl || false;
     console.assert(!!options.router);
 
     this.router_ = options.router;
@@ -159,8 +165,13 @@ export default class TrackManager<POIMeta> {
         layerFilter: l => l === options.trackLayer,
         hitTolerance: this.hitTolerance_,
       });
-      const cursor = (this.interaction_.getActive() && hover) ? 'pointer' : '';
-      if (this.map_.getTargetElement().style.cursor !== cursor) {
+      let cursor: string;
+      if (this.interaction_.getActive() && hover) {
+         cursor = 'pointer'
+      } else if (!this.interaction_.getActive() && !this.viewModePointerControl_) {
+          cursor = ''
+      }
+      if (cursor && this.map_.getTargetElement().style.cursor !== cursor) {
         this.map_.getTargetElement().style.cursor = cursor;
       }
       if (!this.interaction_.getActive() && this.trackHoverEventListeners_.length > 0) {

--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -51,7 +51,7 @@ export interface Options {
    */
   hitTolerance: number;
   /**
-   * Allows users to control cursor style in view mode. 
+   * Allows client applications to control cursor style in view mode. 
    */
   viewModePointerControl: boolean;
 }
@@ -168,7 +168,7 @@ export default class TrackManager<POIMeta> {
       let cursor: string;
       if (this.interaction_.getActive() && hover) {
          cursor = 'pointer'
-      } else if (!this.interaction_.getActive() && !this.viewModePointerControl_) {
+      } else if (!this.viewModePointerControl_ || !hover) {
           cursor = ''
       }
       if (cursor && this.map_.getTargetElement().style.cursor !== cursor) {

--- a/src/interaction/TrackManager.ts
+++ b/src/interaction/TrackManager.ts
@@ -50,10 +50,6 @@ export interface Options {
    * Pixel tolerance for considering the pointer close enough to a segment for snapping.
    */
   hitTolerance: number;
-  /**
-   * Allows client applications to control cursor style in view mode. 
-   */
-  cursorStyleControl: boolean;
 }
 
 
@@ -70,7 +66,6 @@ export default class TrackManager<POIMeta> {
   }
   private shadowTrackLayer_: VectorLayer<VectorSource>;
   private hitTolerance_: number;
-  private cursorStyleControl_ = false;
   public snapping = true;
   private mode_: TrackMode = '';
   private submode_: TrackSubMode = '';
@@ -97,7 +92,6 @@ export default class TrackManager<POIMeta> {
     this.trackLayer_ = options.trackLayer;
     this.shadowTrackLayer_ = options.shadowTrackLayer;
     this.hitTolerance_ = options.hitTolerance !== undefined ? options.hitTolerance : 20;
-    this.cursorStyleControl_ = options.cursorStyleControl || false;
     console.assert(!!options.router);
 
     this.router_ = options.router;


### PR DESCRIPTION
TrackManager currently overrides the cursor style on view mode. This change allow client applications to control the pointer when in view mode 